### PR TITLE
⬆️ UPGRADE: Autoupdate pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,12 +11,12 @@ repos:
         args: [--remove]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.19.1
+    rev: v2.19.4
     hooks:
       - id: pyupgrade
         # args: [--py36-plus]
   - repo: https://github.com/python/black
-    rev: 21.5b2
+    rev: 21.6b0
     hooks:
       - id: black
         language_version: python3
@@ -38,7 +38,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.812
+    rev: v0.902
     hooks:
       - id: mypy
         exclude: ^docs
@@ -65,12 +65,12 @@ repos:
         additional_dependencies: [rstcheck, sphinx]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: rst-backticks
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.0.0
+    rev: v2.1.0
     hooks:
       - id: codespell
         files: (.py|.rst)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ repos:
     hooks:
       - id: mypy
         exclude: ^docs
+        additional_dependencies: [types-click, types-Flask, types-Jinja2]
 
   - repo: https://github.com/PyCQA/pydocstyle
     rev: 6.1.1


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/s-weigand/tv-pyremote/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>pip install pre-commit</em></summary>

```Shell
Collecting pre-commit
  Downloading pre_commit-2.13.0-py2.py3-none-any.whl (190 kB)
Collecting identify>=1.0.0
  Downloading identify-2.2.10-py2.py3-none-any.whl (98 kB)
Collecting cfgv>=2.0.0
  Downloading cfgv-3.3.0-py2.py3-none-any.whl (7.3 kB)
Collecting nodeenv>=0.11.1
  Downloading nodeenv-1.6.0-py2.py3-none-any.whl (21 kB)
Collecting toml
  Downloading toml-0.10.2-py2.py3-none-any.whl (16 kB)
Collecting pyyaml>=5.1
  Downloading PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl (630 kB)
Collecting virtualenv>=20.0.8
  Downloading virtualenv-20.4.7-py2.py3-none-any.whl (7.2 MB)
Collecting appdirs<2,>=1.4.3
  Downloading appdirs-1.4.4-py2.py3-none-any.whl (9.6 kB)
Collecting distlib<1,>=0.3.1
  Downloading distlib-0.3.2-py2.py3-none-any.whl (338 kB)
Collecting filelock<4,>=3.0.0
  Downloading filelock-3.0.12-py3-none-any.whl (7.6 kB)
Collecting six<2,>=1.9.0
  Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
Installing collected packages: six, filelock, distlib, appdirs, virtualenv, toml, pyyaml, nodeenv, identify, cfgv, pre-commit
Successfully installed appdirs-1.4.4 cfgv-3.3.0 distlib-0.3.2 filelock-3.0.12 identify-2.2.10 nodeenv-1.6.0 pre-commit-2.13.0 pyyaml-5.4.1 six-1.16.0 toml-0.10.2 virtualenv-20.4.7
```



</details>
<details>
<summary><em>pre-commit autoupdate || (exit 0);</em></summary>

```Shell
Updating https://github.com/pre-commit/pre-commit-hooks ... [INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
already up to date.
Updating https://github.com/asottile/pyupgrade ... [INFO] Initializing environment for https://github.com/asottile/pyupgrade.
updating v2.19.1 -> v2.19.4.
Updating https://github.com/python/black ... [INFO] Initializing environment for https://github.com/python/black.
updating 21.5b2 -> 21.6b0.
Updating https://github.com/pre-commit/mirrors-prettier ... [INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier.
already up to date.
Updating https://github.com/thibaudcolas/curlylint ... [INFO] Initializing environment for https://github.com/thibaudcolas/curlylint.
already up to date.
Updating https://gitlab.com/pycqa/flake8 ... [INFO] Initializing environment for https://gitlab.com/pycqa/flake8.
already up to date.
Updating https://github.com/PyCQA/isort ... [INFO] Initializing environment for https://github.com/PyCQA/isort.
already up to date.
Updating https://github.com/pre-commit/mirrors-mypy ... [INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy.
updating v0.812 -> v0.902.
Updating https://github.com/PyCQA/pydocstyle ... [INFO] Initializing environment for https://github.com/PyCQA/pydocstyle.
already up to date.
Updating https://github.com/terrencepreilly/darglint ... [INFO] Initializing environment for https://github.com/terrencepreilly/darglint.
already up to date.
Updating https://github.com/econchick/interrogate ... [INFO] Initializing environment for https://github.com/econchick/interrogate.
already up to date.
Updating https://github.com/myint/rstcheck ... 
=====> /home/runner/.cache/pre-commit/repogg10v8yt/.pre-commit-hooks.yaml is not a file
Updating https://github.com/pre-commit/pygrep-hooks ... [INFO] Initializing environment for https://github.com/pre-commit/pygrep-hooks.
updating v1.8.0 -> v1.9.0.
Updating https://github.com/codespell-project/codespell ... [INFO] Initializing environment for https://github.com/codespell-project/codespell.
updating v2.0.0 -> v2.1.0.
Updating https://github.com/asottile/yesqa ... [INFO] Initializing environment for https://github.com/asottile/yesqa.
already up to date.
Updating https://github.com/econchick/interrogate ... already up to date.
```



</details>
<details>
<summary><em>pre-commit run -a || (exit 0);</em></summary>

```Shell
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier:prettier@2.3.1.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/pyupgrade.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/python/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/thibaudcolas/curlylint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://gitlab.com/pycqa/flake8.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-mypy.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/pydocstyle.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/terrencepreilly/darglint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/econchick/interrogate.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/myint/rstcheck.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/codespell-project/codespell.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/yesqa.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Check python ast.........................................................Passed
Check builtin type constructor use.......................................Passed
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
Debug Statements (Python)................................................Passed
Fix python encoding pragma...............................................Passed
pyupgrade................................................................Passed
black....................................................................Passed
prettier.................................................................Passed
curlylint................................................................Passed
flake8...................................................................Passed
isort....................................................................Passed
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

tv_pyremote/cli.py:5: error: Library stubs not installed for "click" (or incompatible with Python 3.9)
tv_pyremote/cli.py:5: note: Hint: "python3 -m pip install types-click"
tests/test_cli.py:6: error: Library stubs not installed for "click.testing" (or incompatible with Python 3.9)
asset_src/utils/render_template.py:7: error: Library stubs not installed for "jinja2" (or incompatible with Python 3.9)
asset_src/utils/render_template.py:7: note: Hint: "python3 -m pip install types-Jinja2"
asset_src/utils/render_template.py:7: note: (or run "mypy --install-types" to install all missing stub packages)
asset_src/utils/render_template.py:7: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
tv_pyremote/api/v1.py:4: error: Library stubs not installed for "flask" (or incompatible with Python 3.9)
tv_pyremote/server.py:2: error: Library stubs not installed for "flask" (or incompatible with Python 3.9)
tv_pyremote/server.py:2: note: Hint: "python3 -m pip install types-Flask"
Found 5 errors in 5 files (checked 12 source files)

pydocstyle...............................................................Passed
darglint.................................................................Passed
interrogate..............................................................Passed
rstcheck.................................................................Passed
rst ``code`` is two backticks............................................Passed
codespell................................................................Passed
Strip unnecessary `# noqa`s..............................................Passed
```



</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- .pre-commit-config.yaml

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)